### PR TITLE
Add tests on new fields of Contract model of Awarding-v3

### DIFF
--- a/openprocurement/auctions/dgf/tests/contract.py
+++ b/openprocurement/auctions/dgf/tests/contract.py
@@ -20,6 +20,8 @@ from openprocurement.auctions.core.tests.blanks.contract_blanks import (
     patch_auction_contract,
     # Auction2LotContractResourceTest
     patch_auction_contract_2_lots,
+    patch_signing_period,
+    patch_date_paid,
 )
 
 
@@ -76,6 +78,8 @@ class AuctionContractResourceTest(BaseAuctionWebTest, AuctionContractResourceTes
         self.app.patch_json('/auctions/{}/awards/{}'.format(self.auction_id, self.award_id), {"data": {"status": "active"}})
 
     test_patch_auction_contract = snitch(patch_auction_contract)
+    test_patch_signing_period = snitch(patch_signing_period)
+    test_patch_date_paid = snitch(patch_date_paid)
 
 
 @unittest.skip("option not available")


### PR DESCRIPTION
Add test on `signingPeriod` of `Contract`
Add test for `datePaid` of `Contract`

---
**Depends on [PR to Core](https://github.com/openprocurement/openprocurement.auctions.core/pull/31)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auctions.dgf/69)
<!-- Reviewable:end -->
