### PR TITLE
A734478612480132 remove admins token

### DIFF
--- a/openprocurement/auctions/dgf/tests/award.py
+++ b/openprocurement/auctions/dgf/tests/award.py
@@ -34,7 +34,7 @@ from openprocurement.auctions.dgf.tests.base import (
 
 class CreateAuctionAwardTest(BaseAuctionWebTest, CreateAuctionAwardTestMixin):
     # initial_data = auction_data
-    initial_status = 'active.qualification'
+    initial_status = 'active.auction'
     initial_bids = test_bids
 
 

--- a/openprocurement/auctions/dgf/tests/bidder.py
+++ b/openprocurement/auctions/dgf/tests/bidder.py
@@ -107,7 +107,9 @@ class AuctionBidderDocumentWithDSResourceTest(BaseAuctionWebTest,
             documentType = auctionProtocol
         """
         # Test POST auctionProtocol document
-        response = self.app.post_json('/auctions/{}/bids/{}/documents'.format(self.auction_id, self.bid_id), {
+        response = self.app.post_json('/auctions/{}/bids/{}/documents?acc_token={}'.format(
+            self.auction_id, self.bid_id, self.bid_token
+        ), {
             'data': {
                 'title': 'name.doc',
                 'url': self.generate_docservice_url(),
@@ -121,7 +123,9 @@ class AuctionBidderDocumentWithDSResourceTest(BaseAuctionWebTest,
         self.assertEqual(response.json['errors'][0]["description"], "Can't add document with auctionProtocol documentType")\
 
         # Test PUT auctionProtocol document
-        response = self.app.post_json('/auctions/{}/bids/{}/documents'.format(self.auction_id, self.bid_id), {
+        response = self.app.post_json('/auctions/{}/bids/{}/documents?acc_token={}'.format(
+            self.auction_id, self.bid_id, self.bid_token
+        ), {
             'data': {
                 'title': 'name.doc',
                 'url': self.generate_docservice_url(),
@@ -133,7 +137,9 @@ class AuctionBidderDocumentWithDSResourceTest(BaseAuctionWebTest,
         doc_id = response.json["data"]['id']
         self.assertIn(doc_id, response.headers['Location'])
 
-        response = self.app.put_json('/auctions/{}/bids/{}/documents/{}'.format(self.auction_id, self.bid_id, doc_id), {
+        response = self.app.put_json('/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, self.bid_id, doc_id, self.bid_token
+        ), {
             'data': {
                 'title': 'name.doc',
                 'url': self.generate_docservice_url(),
@@ -146,7 +152,9 @@ class AuctionBidderDocumentWithDSResourceTest(BaseAuctionWebTest,
         self.assertEqual(response.json['errors'][0]["description"], "Can't update document with auctionProtocol documentType")\
 
         # Test PATCH auctionProtocol document
-        response = self.app.patch_json('/auctions/{}/bids/{}/documents/{}'.format(self.auction_id, self.bid_id, doc_id), {
+        response = self.app.patch_json('/auctions/{}/bids/{}/documents/{}?acc_token={}'.format(
+            self.auction_id, self.bid_id, doc_id, self.bid_token
+        ), {
             'data': {
                 'documentType': 'auctionProtocol'
             }}, status=403)

--- a/openprocurement/auctions/dgf/tests/cancellation.py
+++ b/openprocurement/auctions/dgf/tests/cancellation.py
@@ -43,8 +43,9 @@ class AuctionCancellationDocumentResourceTest(BaseAuctionWebTest,
     def setUp(self):
         super(AuctionCancellationDocumentResourceTest, self).setUp()
         # Create cancellation
-        response = self.app.post_json('/auctions/{}/cancellations'.format(
-            self.auction_id), {'data': {'reason': 'cancellation reason'}})
+        response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+            self.auction_id, self.auction_token
+        ), {'data': {'reason': 'cancellation reason'}})
         cancellation = response.json['data']
         self.cancellation_id = cancellation['id']
 

--- a/openprocurement/auctions/dgf/tests/chronograph.py
+++ b/openprocurement/auctions/dgf/tests/chronograph.py
@@ -164,7 +164,7 @@ class AuctionAwardSwitch2ResourceTest(BaseAuctionWebTest):
 class AuctionLotAuctionPeriodResourceTest(AuctionAuctionPeriodResourceTest):
     initial_lots = test_lots
 
-
+@unittest.skip("option not available")
 class AuctionComplaintSwitchResourceTest(BaseAuctionWebTest):
 
     test_switch_to_pending = snitch(switch_to_pending)

--- a/openprocurement/auctions/dgf/tests/complaint.py
+++ b/openprocurement/auctions/dgf/tests/complaint.py
@@ -24,6 +24,7 @@ class AuctionLotAwardComplaintResourceTest(BaseAuctionWebTest):
     test_create_auction_complaint_lot = snitch(create_auction_complaint_lot)
 
 
+@unittest.skip("option not available")
 class AuctionComplaintDocumentResourceTest(BaseAuctionWebTest, InsiderAuctionComplaintDocumentResourceTestMixin):
 
     def setUp(self):
@@ -36,6 +37,7 @@ class AuctionComplaintDocumentResourceTest(BaseAuctionWebTest, InsiderAuctionCom
         self.complaint_owner_token = response.json['access']['token']
 
 
+@unittest.skip("option not available")
 class FinancialAuctionComplaintResourceTest(BaseAuctionWebTest):
     initial_data = test_financial_auction_data
     initial_organization = test_financial_organization
@@ -47,6 +49,7 @@ class FinancialAuctionLotAwardComplaint(BaseAuctionWebTest):
     initial_organization = test_financial_organization
 
 
+@unittest.skip("option not available")
 class FinancialAuctionComplaintDocumentResourceTest(BaseAuctionWebTest):
     initial_data = test_financial_auction_data
     initial_organization = test_financial_organization
@@ -63,6 +66,7 @@ def suite():
     return tests
 
 
+@unittest.skip("option not available")
 class AuctionComplaintResourceTest(BaseAuctionWebTest, AuctionComplaintResourceTestMixin):
     """Test Case for Auction Complaint resource"""
 

--- a/openprocurement/auctions/dgf/tests/contract.py
+++ b/openprocurement/auctions/dgf/tests/contract.py
@@ -93,7 +93,6 @@ class AuctionContractProlongationResourceTest(BaseAuctionWebTest, AuctionContrac
 
     def setUp(self):
         super(AuctionContractProlongationResourceTest, self).setUp()
-        self.app.authorization = ('Basic', ('token', ''))
         fixtures.create_award(self)
         self.contract_id = self.award_contract_id # use autocreated contract
         fixtures.create_prolongation(self, 'prolongation_id')

--- a/openprocurement/auctions/dgf/tests/fixtures.py
+++ b/openprocurement/auctions/dgf/tests/fixtures.py
@@ -60,9 +60,6 @@ def create_award(test_case):
     test_case.award_value = test_case.award['value']
     test_case.award_suppliers = test_case.award['suppliers']
 
-    test_case.set_status('active.qualification')
-
-    test_case.app.authorization = ('Basic', ('token', ''))
     response = test_case.app.post_json(
         '/auctions/{}/awards/{}/documents?acc_token={}'.format(
             test_case.auction_id,
@@ -103,16 +100,18 @@ def create_award(test_case):
     test_case.assertEqual(response.json["data"]["author"], 'auction_owner')
 
     test_case.app.patch_json(
-        '/auctions/{}/awards/{}'.format(
+        '/auctions/{}/awards/{}?acc_token={}'.format(
             test_case.auction_id,
-            test_case.award_id
+            test_case.award_id,
+            test_case.auction_token
         ),
         {"data": {"status": "pending"}}
     )
     test_case.app.patch_json(
-        '/auctions/{}/awards/{}'.format(
+        '/auctions/{}/awards/{}?acc_token={}'.format(
             test_case.auction_id,
-            test_case.award_id
+            test_case.award_id,
+            test_case.auction_token
         ),
         {"data": {"status": "active"}}
     )

--- a/openprocurement/auctions/dgf/tests/migration.py
+++ b/openprocurement/auctions/dgf/tests/migration.py
@@ -257,13 +257,15 @@ class MigrateTestFrom2To3Schema(BaseAuctionWebTest):
         self.assertIn('endDate', auction['awards'][0]['complaintPeriod'])
         self.assertEqual(auction['status'], 'active.awarded')
 
-        response = self.app.post('/auctions/{}/contracts/{}/documents'.format(
-            self.auction_id, contract['id']), upload_files=[('file', 'name.doc', 'content')])
+        response = self.app.post('/auctions/{}/contracts/{}/documents?acc_token={}'.format(
+            self.auction_id, contract['id'], self.auction_token
+        ), upload_files=[('file', 'name.doc', 'content')])
         self.assertEqual(response.status, '201 Created')
         self.assertEqual(response.content_type, 'application/json')
 
-        response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, auction['contracts'][0]['id']),
-                                       {"data": {"status": "active"}})
+        response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+            self.auction_id, auction['contracts'][0]['id'], self.auction_token
+        ), {"data": {"status": "active"}})
         self.assertEqual(response.status, '200 OK')
         self.assertEqual(response.content_type, 'application/json')
         self.assertEqual(response.json['data']['status'], u'active')


### PR DESCRIPTION
Remove usage of 'admins' token in tests

### Depends on:

- https://github.com/openprocurement/openprocurement.auctions.core/pull/152

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auctions.dgf/110)
<!-- Reviewable:end -->
